### PR TITLE
Correct extension by removing full stop

### DIFF
--- a/docs/06_SAP_Fiori_Elements/custom-actions-02fb273.md
+++ b/docs/06_SAP_Fiori_Elements/custom-actions-02fb273.md
@@ -50,7 +50,7 @@ To define custom action in quick view cards:
         
         "extends": {
                 "extensions": {
-                     "sap.ui.controller.Extensions": {
+                     "sap.ui.controllerExtensions": {
                              "sap.ovp.app.Main": {
                                          "controllerName": "my_app.ext.controller.OverViewPageExt"
                               }


### PR DESCRIPTION
At least in 1.71 this fullstop is not required - Assume it hasn't changed