### PR TITLE
Update using-mock-data-with-the-odata-v2-mock-server-a428d41.md

### DIFF
--- a/docs/04_Essentials/using-mock-data-with-the-odata-v2-mock-server-a428d41.md
+++ b/docs/04_Essentials/using-mock-data-with-the-odata-v2-mock-server-a428d41.md
@@ -10,7 +10,7 @@ To switch to mock mode, set the URL parameter `responderOn` to `true`. We recomm
 // module:model/Config
 sap.ui.define(["sap/base/util/UriParameters"], function(UriParameters) {
     return {
-        isMock: ("true" === UriParameters.fromUrl(window.location.href).get("responderOn"));
+        isMock: ("true" === UriParameters.fromURL(window.location.href).get("responderOn"));
     }
 });
 ```


### PR DESCRIPTION
The function in line 13 is called _fromURL_ and not _fromUrl_
API Ref: https://sapui5.hana.ondemand.com/sdk/#/api/module:sap/base/util/UriParameters%23overview