### PR TITLE
[FIX] Replace em dash with two hyphens in snippets

### DIFF
--- a/docs/04_Essentials/enabling-responsive-paddings-according-to-the-control-width-3b718b5.md
+++ b/docs/04_Essentials/enabling-responsive-paddings-according-to-the-control-width-3b718b5.md
@@ -548,5 +548,5 @@ To call the utility, when initializing the control, use:
 MyCustomControl._initResponsivePaddingsEnablement()
 ```
 
-As a result, application developers will be able to use classes, such as `sapUiResponsivePadding—header` and `sapUiResponsivePadding--content`, to enable the paddings on the respective element.
+As a result, application developers will be able to use classes, such as `sapUiResponsivePadding--header` and `sapUiResponsivePadding--content`, to enable the paddings on the respective element.
 

--- a/docs/05_Developing_Apps/performance-issues-966d67c.md
+++ b/docs/05_Developing_Apps/performance-issues-966d67c.md
@@ -82,7 +82,7 @@ View:
 <mvc:View xmlns:mvc="sap.ui.core.mvc" xmlns="sap.m" controllerName="my.own.controller">
 	<Page>
             
-		<!—only the initially needed display panel -->
+		<!-- only the initially needed display panel -->
 		<Panel id="displayPanel" headerText="Display Data">
 			<Table...>
 		</Panel>

--- a/docs/10_More_About_Controls/semantic-page-sap-f-47dc868.md
+++ b/docs/10_More_About_Controls/semantic-page-sap-f-47dc868.md
@@ -155,13 +155,13 @@ Adding semantic content:
    <semantic:SemanticPage>
       ...
 
-      <!— will automatically create a button with “email” icon and style and position it in accord with the underlying semantics -->
+      <!-- will automatically create a button with “email” icon and style and position it in accord with the underlying semantics -->
       <semantic:sendEmailAction press=”onSendEmailPress >
          <semantic:SendEmailAction />
       </semantic:sendEmailAction>
 
 
-     <!— will automatically create a button with icon, styling and positioning in accord with the underlying semantics -->
+     <!-- will automatically create a button with icon, styling and positioning in accord with the underlying semantics -->
       <semantic:discussInJamAction press=”onDiscussInJamPress”>
          <semantic:DiscussInJamAction />
       </semantic:discussInJamAction>
@@ -192,7 +192,7 @@ Adding custom \(non-semantic\) content
 
 <!-- Header Content -->
 <semantic:headerContent>
-      <!—custom header Content goes here -->
+      <!-- custom header Content goes here -->
 <FlexBox
       alignItems="Start"
       justifyContent="SpaceBetween">
@@ -211,9 +211,9 @@ Adding custom \(non-semantic\) content
 </semantic:headerContent>
 
 
-<!—Content -->
+<!-- Content -->
 <semantic:content>
-    <!—Custom page-body content gies here -->
+    <!-- Custom page-body content gies here -->
    <Table
       id="idProductsTable"
       inset="false"

--- a/docs/10_More_About_Controls/semantic-page-sap-m-4a97a07.md
+++ b/docs/10_More_About_Controls/semantic-page-sap-m-4a97a07.md
@@ -208,26 +208,26 @@ The `DetailPage` usually displays extended information for the item that was sel
                             navButtonPress="onNavButtonPress">
 
                           <semantic:customHeaderContent>
-                   <!—custom header controls go here -->
+                   <!-- custom header controls go here -->
                   <Button text="CustomHeaderBtn" press="onHeaderBtnPress"/>
                </semantic:customHeaderContent>
 
 
                <semantic:content>
-                   <!—custom page content goes here -->
+                   <!-- custom page content goes here -->
                   <semantic:AddAction press="onSemanticButtonPress"/>
                </semantic:content>
 
 
                           <semantic:customFooterContent>
-                   <!—custom footer controls go here -->
+                   <!-- custom footer controls go here -->
                   <Button text="CustomFooterBtn" press="onFooterBtnPress"/>
                   <OverflowToolbarButton icon="sap-icon://settings" text="Settings" press="onSettingsPress"/>
                </semantic:customFooterContent>
 
 
                           <semantic:customShareMenuContent>
-                   <!—custom share-menu controls go here -->
+                   <!-- custom share-menu controls go here -->
                   <Button text="CustomShareMenuBtn" press="onShareMenuBtnPress"/>
                </semantic: customShareMenuContent >
 


### PR DESCRIPTION
Some code snippets (inline or code blocks) were containing the syntactically invalid _em dash_ (`—`) characters.

This change replaces `—` with two hyphens `--` to correct the code syntax.