### PR TITLE
Added a note to a current bug

### DIFF
--- a/docs/06_SAP_Fiori_Elements/highlighting-line-items-based-on-criticality-0d501b1.md
+++ b/docs/06_SAP_Fiori_Elements/highlighting-line-items-based-on-criticality-0d501b1.md
@@ -74,6 +74,9 @@ Add a `LineItem` criticality annotation for the line items of the entity type th
 > 
 > ```
 
+> ### Note:  
+> If using a qualifier on fields and on the line item criticality, there must be at least one field with the default qualifier.
+
 > ### Sample Code:  
 > CAP CDS Annotation
 > 


### PR DESCRIPTION
If using a line item criticality with a qualifier, at least one field without a qualifier must be included in the view to take effect. This is probably a bug, maybe should be escalated to the devs.