### PR TITLE
Remove duplicate entry "sap.m.IconTabBar"

### DIFF
--- a/docs/04_Essentials/using-container-content-padding-css-classes-c71f6df.md
+++ b/docs/04_Essentials/using-container-content-padding-css-classes-c71f6df.md
@@ -25,7 +25,6 @@ The following list of controls support container content padding CSS classes:
 -   `sap.f.semantic.SemanticPage`
 -   `sap.m.Carousel`
 -   `sap.m.Dialog`
--   `sap.m.IconTabBar`
 -   `sap.m.FlexBox` using `FlexItemData` with `styleClass` property for each item
 -   `sap.m.IconTabBar`
 -   `sap.m.List`


### PR DESCRIPTION
The list of controls supporting certain CSS classes contained module "sap.m.IconTabBar" twice. Since the list seems to be sorted alphabetically, the first entry should be the undesired one.