### PR TITLE
fix: docs: Remove unexpected bracket in test-automation example

### DIFF
--- a/docs/04_Essentials/test-automation-ae44824.md
+++ b/docs/04_Essentials/test-automation-ae44824.md
@@ -101,7 +101,7 @@ You have installed the *current* or *LTS* version of *Node.js* from [https://nod
         browsers: ["Chrome"]
         
         });
-      });
+      };
     ```
 
     Adapt the URL \(<code><i class="varname">&lt;server\&gt;</i>:<i class="varname">&lt;port\&gt;</i></code> to the SAPUI5 resources according to your installation. You can also use SAPUI5 from a content delivery network, see [Variant for Bootstrapping from Content Delivery Network](variant-for-bootstrapping-from-content-delivery-network-2d3eb2f.md).


### PR DESCRIPTION
* Fixes `SyntaxError: Unexpected token ')'` with the example config