### PR TITLE
Fix typo: MessageTost -> MessageToast

### DIFF
--- a/docs/10_More_About_Controls/message-handling-f5df293.md
+++ b/docs/10_More_About_Controls/message-handling-f5df293.md
@@ -59,7 +59,7 @@ For showing messages to the user that are related to the currrent page, you have
 > ### Example:  
 > ```js
 > 	// add MessageToast as import
-> 	sap.ui.define([..., 'sap/m/MessageTost', ...], function(..., MessageToast, ...) {
+> 	sap.ui.define([..., 'sap/m/MessageToast', ...], function(..., MessageToast, ...) {
 > 
 > 		...
 > 		// show toast when needed


### PR DESCRIPTION
I did not test it, but I think it's supposed to say "MessageToast"?