### PR TITLE
Update text-classification-582ce93.md

### DIFF
--- a/docs/05_Developing_Apps/text-classification-582ce93.md
+++ b/docs/05_Developing_Apps/text-classification-582ce93.md
@@ -19,7 +19,7 @@ The complete line must have one of the following patterns \(text type is mandato
 
 We recommend that you assign a text type to each text. The text type indicates to which user interface element the text is related. You can use the following main text types:
 
--   For short texts \(less than 120 characters\) :
+-   For short texts \(up to 120 characters\) :
 
 
     <table>


### PR DESCRIPTION
Text says currently: less than 120 characters and more than 120 characters.

That's first up to 119 chars and than starting from 121 chars. Exactly 120 chars is omitted? I guess the first text means to include 120 chars? So its up to 120 chars, right?