### PR TITLE
Fix Incorrect Definition in init Function

### DIFF
--- a/docs/03_Get-Started/step-26-mock-server-configuration-bae9d90.md
+++ b/docs/03_Get-Started/step-26-mock-server-configuration-bae9d90.md
@@ -197,7 +197,7 @@ sap.ui.define([
 	"use strict";
 
 	return {
-		init: () {
+		init () {
 			// create
 			const oMockServer = new MockServer({
 				rootUri: sap.ui.require.toUrl("ui5/walkthrough") + "/V2/Northwind/Northwind.svc/"


### PR DESCRIPTION
The function defination of init in doc is inconsistent with the actual code, the later one is right.
![图片](https://github.com/SAP-docs/sapui5/assets/16676760/b7df55d9-98bb-4def-a7b6-476384670909)

![图片](https://github.com/SAP-docs/sapui5/assets/16676760/e68d8574-dcab-49ee-9d76-9485fb1eb2ee)
I think both ```init () { }``` and ```init: () => { }``` are right, but ```init: () { }``` is not.