### PR TITLE
Fix: Import "ResourceModel" in QUnit Test File

### DIFF
--- a/docs/03_Get-Started/step-27-unit-test-with-qunit-e1ce1de.md
+++ b/docs/03_Get-Started/step-27-unit-test-with-qunit-e1ce1de.md
@@ -35,12 +35,13 @@ We add a new folder `unit` under the `test` folder and a `model` subfolder where
 
 
 
-## webapp/test/unit/model/formatter.js
+## webapp/test/unit/model/formatter.js \(New\)
 
 ```js
 sap.ui.define([
-	"ui5/walkthrough/model/formatter"
-], (formatter) => {
+	"ui5/walkthrough/model/formatter",
+	"sap/ui/model/resource/ResourceModel"
+], (formatter, ResourceModel) => {
 	"use strict";
 
 	QUnit.module("Formatting functions", {});


### PR DESCRIPTION
1, Add a "(New)" it is a new file.
2, "ResourceModel" was not being properly imported in the doc, and we can find it in the actual code.
![图片](https://github.com/SAP-docs/sapui5/assets/16676760/f430f418-75f1-4ef3-8f7d-81728cbeb8e8)

![图片](https://github.com/SAP-docs/sapui5/assets/16676760/9f392165-25fb-4a8c-81ca-c061577a4c46)

