### PR TITLE
Update enabling-editing-using-a-dialog-mass-edit-965ef5b.md

### DIFF
--- a/docs/06_SAP_Fiori_Elements/enabling-editing-using-a-dialog-mass-edit-965ef5b.md
+++ b/docs/06_SAP_Fiori_Elements/enabling-editing-using-a-dialog-mass-edit-965ef5b.md
@@ -62,6 +62,7 @@ The following prerequisites apply:
 
 -   On the object page, *Mass Edit* is only available in edit mode.
 
+-   For service backends based on CAP Node.js, support for mass edit must be enabled by setting a feature flag as described in the [CAP documentation](https://cap.cloud.sap/docs/releases/dec23#sapui5-mass-edit).
 
 Once a user clicks on the *Mass Edit* button, a dialog opens showing all the editable and visible fields from the table. The user is able to set a value for every editable field of the selected records, or even clear all values for the field from the selected records in one go.
 


### PR DESCRIPTION
Mass edit is now also supported by CAP Node.js, but requires a feature flag configured in the service definition.
CAP Java doesn't require this feature flag, as it supported mass edit from the very beginning.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

