### PR TITLE
docs(FE): Fix CAP CDS annotation for LineItem

### DIFF
--- a/docs/06_SAP_Fiori_Elements/tables-c0f6592.md
+++ b/docs/06_SAP_Fiori_Elements/tables-c0f6592.md
@@ -167,7 +167,7 @@ You can hide the table columns or specific fields within the table column in an 
 >         {
 >             $Type             : 'UI.DataFieldForAnnotation',
 >             Target            : '@UI.FieldGroup#multipleActionFields',
->             Label             : 'Sold-To Party,
+>             Label             : 'Sold-To Party',
 >             ![@UI.Hidden] : Delivered
 >         }
 > ]


### PR DESCRIPTION
A single quote was missing in the snippet.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

