### PR TITLE
Update step-26-mock-server-configuration-typescript-3e1c64f.md

### DIFF
--- a/docs/03_Get-Started/step-26-mock-server-configuration-typescript-3e1c64f.md
+++ b/docs/03_Get-Started/step-26-mock-server-configuration-typescript-3e1c64f.md
@@ -161,7 +161,7 @@ export default {
         const urlParams = new URLSearchParams(window.location.search);
 
         // configure mock server with a delay
-        mockServer.config({
+        MockServer.config({
             autoRespond: true,
             autoRespondAfter: parseInt(urlParams.get("serverDelay") || "500")
         });


### PR DESCRIPTION
The config method is a static method, which means it's a property of the class itself, not an instance of the class. We can access it using MockServer.config instead of mockServer.config.

<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

