### PR TITLE
docs: fix step-23-filtering-5295470.md

### DIFF
--- a/docs/03_Get-Started/step-23-filtering-5295470.md
+++ b/docs/03_Get-Started/step-23-filtering-5295470.md
@@ -70,8 +70,6 @@ sap.ui.define([
 	"use strict";
 
 	return Controller.extend("ui5.walkthrough.controller.InvoiceList", {
-		formatter: formatter, 
-
 		onInit() {
 			const oViewModel = new JSONModel({
 				currency: "EUR"


### PR DESCRIPTION
Removing the formatter property in the controller. 
The formatter property is not used (even from the associated view) and is assigned a nonexistent value. 

_It seems that it is a leftover from an old version which no longer has any reason to exist; now formatter modules are directly loaded into the view via sap.ui.core.require._


