### PR TITLE
[spelling-mistake] Fix minor spelling mistake in Typescript Walkthrough Step 8

### DIFF
--- a/docs/03_Get-Started/step-8-translatable-texts-typescript-4dcf52e.md
+++ b/docs/03_Get-Started/step-8-translatable-texts-typescript-4dcf52e.md
@@ -31,7 +31,7 @@ You can view all files at [OpenUI5 TypeScript Walkthrough - Step 8: Translatable
 
 ## webapp/i18n/i18n.properties \(New\)
 
-The `i18n` file allows you to store translated texts for multiple languages, making your application accessible to a wider audience. In oder to achive this, the `properties` file for texts contains name-value pairs for each element. You can add any number of parameters to the texts by enclosing them in curly brackets with corresponding numbers. These numbers correspond to the sequence in which the parameters are accessed \(starting with 0\).
+The `i18n` file allows you to store translated texts for multiple languages, making your application accessible to a wider audience. In order to achive this, the `properties` file for texts contains name-value pairs for each element. You can add any number of parameters to the texts by enclosing them in curly brackets with corresponding numbers. These numbers correspond to the sequence in which the parameters are accessed \(starting with 0\).
 
 To set up the `i18n` file, we navigate to the `webapp` folder and create a new folder named `i18n`. Inside this folder, we place an `i18n.properties` file, which serves as a storage for our translated texts. We add two name-value pairs to our properties file: The `showHelloButtonText` name represents the text for the button on our app view. The `helloMsg` name represents the greeting message we'll display in the message toast. To include the appropriate recipient's name in the message, we use a placeholder with the greeting message text.
 


### PR DESCRIPTION
Fix minor spelling mistake `oder` to `order`

This is related to issue #200 
<!-------------------------------------------------------------------------------------------
Note that this proposal is visible on github.com for anyone to see.
Refrain from sharing sensitive information.
-------------------------------------------------------------------------------------------->

