### PR TITLE
Add a Specific Restriction for "wasm-unsafe-eval"

### DIFF
--- a/docs/05_Developing_Apps/content-security-policy-fe1a6db.md
+++ b/docs/05_Developing_Apps/content-security-policy-fe1a6db.md
@@ -606,6 +606,23 @@ When native hyphenation is not available, a third-party library \(Hyphenopoly\) 
 </td>
 </tr>
 <tr>
+<td valign="top">
+
+`sap.ndc.BarcodeScanner`
+
+</td>
+<td valign="top">
+
+BarcodeScanner
+
+</td>
+<td valign="top">
+
+`script-src` requires `wasm-unsafe-eval`
+
+</td>
+</tr>
+<tr>
 <td valign="top" align="center" colspan="3">
 
 <code><b>style-src 'unsafe-inline'</b></code>


### PR DESCRIPTION
For sap.ndc.BarcodeScanner, add a specific restriction in CSP section.

