### PR TITLE
docs: fix link for PseudoEvents API reference

### DIFF
--- a/docs/09_Developing_Controls/event-handler-methods-bdf3e98.md
+++ b/docs/09_Developing_Controls/event-handler-methods-bdf3e98.md
@@ -27,5 +27,5 @@ onsapnext: function(events) {
 
 [API Reference: `ControlEvents`](https://ui5.sap.com/#/api/module%3Asap%2Fui%2Fevents%2FControlEvents)
 
-[API Reference: `PseudoEvents`](https://ui5.sap.com/#/api/module%3Asap%2Fui%2Fevents%2FPseudoEvents.events)
+[API Reference: `PseudoEvents`](https://ui5.sap.com/#/api/module%3Asap%2Fui%2Fevents%2FPseudoEvents)
 


### PR DESCRIPTION
Previous link, while more specific, leads to a 404. The updated link equals the same 'style'/'target' as the ControlEvents url.

